### PR TITLE
Update integration test

### DIFF
--- a/metallb/v0.14.5/speaker/rockcraft.yaml
+++ b/metallb/v0.14.5/speaker/rockcraft.yaml
@@ -43,7 +43,7 @@ parts:
         ./frr-tools/metrics/exporter.go
 
       # build speaker
-      go build -v -o $CRAFT_PART_INSTALL/speaker \
+      CGO_ENABLED=0 go build -v -o $CRAFT_PART_INSTALL/speaker \
         -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
         ./speaker
 


### PR DESCRIPTION
At the moment, the integration test is deploying the metallb chart without actually ensuring that the deployment succeeded.

We'll add the appropriate assertions, as well as some necessary helm settings:

* we'll explicitly pass the container commands, bypassing Pebble.
  * Pebble cannot handle read-only filesystems. It attempts to write a file before starting the services and it hangs for 5 minutes before entering a restart loop if it doesn't have write permissions.
* we have to run the container processes as root
  * frr bug: https://bugzilla.redhat.com/show_bug.cgi?id=2147522
* the chart version needs to be pinned, newer chart versions are not compatible with this image

While at it, we'll set CGO_ENABLED=0 when building the metallb speaker as per the reference image, thus linking it statically.