### PR TITLE
Changes rock bases to bare

### DIFF
--- a/metallb/v0.14.5/controller/rockcraft.yaml
+++ b/metallb/v0.14.5/controller/rockcraft.yaml
@@ -6,7 +6,7 @@ description: >
 version: v0.14.5
 license: Apache-2.0
 
-base: ubuntu@22.04
+base: bare
 build-base: ubuntu@22.04
 platforms:
   amd64:
@@ -20,6 +20,22 @@ services:
     startup: enabled
 
 parts:
+  add-base-files:
+    plugin: nil
+    stage-packages:
+      # Original Dockerfile uses gcr.io/distroless/static:latest as a base.
+      # This image contains the following:
+      # https://github.com/GoogleContainerTools/distroless/blob/1533e54a73805ec13fe0cc68218fc7a215a0a6f7/base/README.md
+      - ca-certificates
+      - tzdata
+      - base-passwd
+
+  # Can't have stage packages and stage slices together, apparently.
+  add-base-slices:
+    plugin: nil
+    stage-packages:
+      - base-files_tmp
+
   build-deps:
     plugin: nil
     build-snaps:

--- a/metallb/v0.14.5/speaker/rockcraft.yaml
+++ b/metallb/v0.14.5/speaker/rockcraft.yaml
@@ -6,7 +6,7 @@ description: >
 version: v0.14.5
 license: Apache-2.0
 
-base: ubuntu@22.04
+base: bare
 build-base: ubuntu@22.04
 platforms:
   amd64:
@@ -20,6 +20,27 @@ services:
     startup: enabled
 
 parts:
+  add-base-files:
+    plugin: nil
+    stage-packages:
+      # Original Dockerfile uses gcr.io/distroless/static:latest as a base.
+      # This image contains the following:
+      # https://github.com/GoogleContainerTools/distroless/blob/1533e54a73805ec13fe0cc68218fc7a215a0a6f7/base/README.md
+      - ca-certificates
+      - tzdata
+      - base-passwd
+      # Helm charts may expect the image to be able to copy some files.
+      - bash
+      - coreutils
+    override-build: |
+      ln -sf bash "${CRAFT_PART_INSTALL}/bin/sh"
+
+  # Can't have stage packages and stage slices together, apparently.
+  add-base-slices:
+    plugin: nil
+    stage-packages:
+      - base-files_tmp
+
   build-deps:
     plugin: nil
     build-snaps:

--- a/tests/sanity/test_metallb_controller.py
+++ b/tests/sanity/test_metallb_controller.py
@@ -27,4 +27,4 @@ def test_sanity():
     assert V0_14_5_EXPECTED_HELPSTR in docker_run.stderr
 
     # check rock filesystem
-    docker_util.ensure_image_contains_paths(rock.image, V0_14_5_EXPECTED_FILES)
+    docker_util.ensure_image_contains_paths_bare(rock.image, V0_14_5_EXPECTED_FILES)

--- a/tests/sanity/test_metallb_speaker.py
+++ b/tests/sanity/test_metallb_speaker.py
@@ -27,4 +27,4 @@ def test_sanity():
     assert V0_14_5_EXPECTED_HELPSTR in docker_run.stderr
 
     # check rock filesystem
-    docker_util.ensure_image_contains_paths(rock.image, V0_14_5_EXPECTED_FILES)
+    docker_util.ensure_image_contains_paths_bare(rock.image, V0_14_5_EXPECTED_FILES)

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -40,11 +40,13 @@ commands =
     black {tox_root}/integration --check --diff
 
 [testenv:sanity]
-description = Run integration tests
+description = Run sanity tests
 deps =
     -r {tox_root}/requirements-test.txt
+allowlist_externals =
+    sudo
 commands =
-    pytest -v \
+    sudo -E {envpython} -m pytest -v \
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \


### PR DESCRIPTION
Switching to a bare-based image will reduce the overall image size and reduces attack surface area.

The original Dockerfile uses ``gcr.io/distroless/static:latest``, which has only a few packages. We can add those packages and switch to a bare-based image.

Helm charts may expect the speaker image to be able to copy some files.

The ``frr`` rock base is not switched to bare as it has quite a few runtime dependencies and it is a bit more complex.

We can no longer use ``ensure_image_contains_paths`` to check if files exist in the rock images, since they are now bare-based. Instead, we can use ``ensure_image_contains_paths_bare``, which checks the image layers instead. Because of this, we need sufficient permissions to check the ``/var/lib/docker`` folder.