### PR TITLE
Add SECURITY.md and CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*               @canonical/kubernetes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security issue, please follow the steps below:
+
+Using GitHub, file a [Private Security Report](https://github.com/canonical/metallb-rocks/security/advisories/new) with:
+- A description of the issue
+- Steps to reproduce the issue
+- Affected versions of the `metallb-rocks` package
+- Any known mitigations for the issue
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what to expect during this process and our requirements for responsible disclosure.
+
+Thank you for contributing to the security and integrity of the `metallb-rocks`!


### PR DESCRIPTION
This pr adds security.md and introduces a policy enabling users to report security issues.

KU-2046