### PR TITLE
ci: Include FIPS openssl in rockcraft parts, Build ARM on LXD

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,8 +17,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      multipass-image: "22.04"
-      rockcraft-revisions: '{"amd64": "3494"}'
+      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/frr/9.1.3/rockcraft.yaml
+++ b/frr/9.1.3/rockcraft.yaml
@@ -93,6 +93,12 @@ parts:
       make -j $(nproc)
       make install
 
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
   frr:
     after: [libyang]
     plugin: nil

--- a/metallb/v0.14.9/controller/rockcraft.yaml
+++ b/metallb/v0.14.9/controller/rockcraft.yaml
@@ -25,6 +25,12 @@ parts:
     build-snaps:
       - go/1.22-fips/stable
 
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
   controller:
     after: [build-deps]
     plugin: go
@@ -32,10 +38,6 @@ parts:
     source: https://github.com/metallb/metallb
     source-tag: v0.14.9
     source-depth: 1
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     override-build: |
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.

--- a/metallb/v0.14.9/speaker/rockcraft.yaml
+++ b/metallb/v0.14.9/speaker/rockcraft.yaml
@@ -25,6 +25,12 @@ parts:
     build-snaps:
       - go/1.23-fips/stable
 
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
   speaker:
     after: [build-deps]
     plugin: go
@@ -32,10 +38,6 @@ parts:
     source: https://github.com/metallb/metallb
     source-tag: v0.14.9
     source-depth: 1
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     override-build: |
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.


### PR DESCRIPTION
### Overview

This PR builds on top of https://github.com/canonical/k8s-workflows/pull/50 and discards multipass as the build environment. Also enables building FIPS-enabled rocks on ARM and only includes OpenSSL from FIPS sources rather than the full core22.