### PR TITLE
test: Add FIPS and pebble version testing

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,12 +8,12 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@bschimke95/fips-tests
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
-      cache-action: skip #${{ (github.event_name == 'push') && 'save' || 'restore' }}
+      cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,12 +8,12 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@bschimke95/fips-tests
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
-      cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
+      cache-action: skip #${{ (github.event_name == 'push') && 'save' || 'restore' }}
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,4 +1,4 @@
-coverage[toml]==7.2.5
+coverage[toml]==7.11.3
 pytest==7.3.1
 PyYAML==6.0.1
 tenacity==8.2.3

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -3,4 +3,4 @@ pytest==7.3.1
 PyYAML==6.0.1
 tenacity==8.2.3
 charmed-kubeflow-chisme>=0.4
-k8s-test-harness @ git+https://github.com/canonical/k8s-test-harness@de46217
+k8s-test-harness @ git+https://github.com/canonical/k8s-test-harness@bschimke95/extend-utils

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -3,4 +3,4 @@ pytest==7.3.1
 PyYAML==6.0.1
 tenacity==8.2.3
 charmed-kubeflow-chisme>=0.4
-k8s-test-harness @ git+https://github.com/canonical/k8s-test-harness@bschimke95/extend-utils
+k8s-test-harness @ git+https://github.com/canonical/k8s-test-harness@main

--- a/tests/sanity/test_frr.py
+++ b/tests/sanity/test_frr.py
@@ -36,7 +36,9 @@ EXPECTED_HELPSTR = "Watchdog program to monitor status of frr daemons"
     ],
 )
 def test_filesystem(image_version: str, expected_files: List[str]):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -44,7 +46,9 @@ def test_filesystem(image_version: str, expected_files: List[str]):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_executable_frr(image_version):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stdout_contains=EXPECTED_HELPSTR
     )
@@ -54,7 +58,9 @@ def test_executable_frr(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_pebble_executable(image_version):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -65,7 +71,9 @@ def test_pebble_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_fips(image_version, GOFIPS):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_frr.py
+++ b/tests/sanity/test_frr.py
@@ -35,8 +35,8 @@ EXPECTED_HELPSTR = "Watchdog program to monitor status of frr daemons"
         ("9.1.3", EXPECTED_FILES),
     ],
 )
-def test_filesystem(version: str, expected_files: List[str]):
-    image = env_util.resolve_image(IMAGE_NAME, version)
+def test_filesystem(image_version: str, expected_files: List[str]):
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -44,7 +44,7 @@ def test_filesystem(version: str, expected_files: List[str]):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_executable_frr(image_version):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stdout_contains=EXPECTED_HELPSTR
     )
@@ -54,7 +54,7 @@ def test_executable_frr(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_pebble_executable(image_version):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -65,7 +65,7 @@ def test_pebble_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_fips(image_version, GOFIPS):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_frr.py
+++ b/tests/sanity/test_frr.py
@@ -38,7 +38,7 @@ EXPECTED_HELPSTR = "Watchdog program to monitor status of frr daemons"
 def test_filesystem(image_version: str, expected_files: List[str]):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -48,7 +48,7 @@ def test_filesystem(image_version: str, expected_files: List[str]):
 def test_executable_frr(image_version):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stdout_contains=EXPECTED_HELPSTR
     )
@@ -60,7 +60,7 @@ def test_executable_frr(image_version):
 def test_pebble_executable(image_version):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -73,7 +73,7 @@ def test_pebble_executable(image_version):
 def test_fips(image_version, GOFIPS):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_frr.py
+++ b/tests/sanity/test_frr.py
@@ -3,12 +3,20 @@
 # See LICENSE file for licensing details
 #
 
-import pytest
-from k8s_test_harness.util import docker_util, env_util
+import shlex
+from pathlib import Path
+from typing import List
 
-# In the future, we may also test ARM
-IMG_PLATFORM = "amd64"
-IMG_NAME = "frr"
+import pytest
+from k8s_test_harness.util import docker_util, env_util, fips_util
+
+TEST_PATH = Path(__file__)
+REPO_PATH = TEST_PATH.parent.parent.parent
+IMAGE_NAME = "frr"
+IMAGE_BASE = f"ghcr.io/canonical/{IMAGE_NAME}"
+IMAGE_ENTRYPOINT = "/usr/lib/frr/watchfrr --help"
+PEBBLE_VERSION = "v1.18.0"
+
 
 EXPECTED_FILES = [
     "/usr/sbin/docker-start",
@@ -19,16 +27,62 @@ EXPECTED_FILES = [
 EXPECTED_HELPSTR = "Watchdog program to monitor status of frr daemons"
 
 
-@pytest.mark.parametrize("frr_version", ["9.0.2", "9.1.0", "9.1.3"])
-def test_sanity(frr_version: str):
-    rock = env_util.get_build_meta_info_for_rock_version(
-        IMG_NAME, frr_version, IMG_PLATFORM
+@pytest.mark.parametrize(
+    "version,expected_files",
+    [
+        ("9.0.2", EXPECTED_FILES),
+        ("9.1.0", EXPECTED_FILES),
+        ("9.1.3", EXPECTED_FILES),
+    ],
+)
+def test_filesystem(version: str, expected_files: List[str]):
+    image = env_util.resolve_image(IMAGE_NAME, version)
+    docker_util.ensure_image_contains_paths_bare(image, expected_files)
+
+
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_executable_frr(image_version):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    docker_util.run_entrypoint_and_assert(
+        image, IMAGE_ENTRYPOINT, expect_stdout_contains=EXPECTED_HELPSTR
     )
 
-    # check rock filesystem
-    docker_util.ensure_image_contains_paths(rock.image, EXPECTED_FILES)
 
-    docker_run = docker_util.run_in_docker(
-        rock.image, ["/usr/lib/frr/watchfrr", "--help"]
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_pebble_executable(image_version):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    docker_util.run_entrypoint_and_assert(
+        image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
-    assert EXPECTED_HELPSTR in docker_run.stdout
+
+
+@pytest.mark.parametrize("GOFIPS", [0, 1], ids=lambda v: f"GOFIPS={v}")
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_fips(image_version, GOFIPS):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    entrypoint = shlex.split(IMAGE_ENTRYPOINT)
+
+    docker_env = ["-e", f"GOFIPS={GOFIPS}"]
+    process = docker_util.run_in_docker(
+        image, entrypoint, check_exit_code=False, docker_args=docker_env
+    )
+
+    rockcraft_yaml = (
+        (REPO_PATH / "frr" / image_version / "rockcraft.yaml").read_text().lower()
+    )
+    expected_returncode, expected_error = fips_util.fips_expectations(
+        rockcraft_yaml, GOFIPS
+    )
+
+    assert (
+        process.returncode == expected_returncode
+    ), f"Return code mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"
+    assert (
+        expected_error in process.stderr
+    ), f"Error message mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"

--- a/tests/sanity/test_frr.py
+++ b/tests/sanity/test_frr.py
@@ -28,7 +28,7 @@ EXPECTED_HELPSTR = "Watchdog program to monitor status of frr daemons"
 
 
 @pytest.mark.parametrize(
-    "version,expected_files",
+    "image_version,expected_files",
     [
         ("9.0.2", EXPECTED_FILES),
         ("9.1.0", EXPECTED_FILES),

--- a/tests/sanity/test_metallb_controller.py
+++ b/tests/sanity/test_metallb_controller.py
@@ -35,8 +35,8 @@ EXPECTED_HELPSTR = "Usage of /controller:"
         ("v0.14.9", V0_14_5_EXPECTED_FILES),
     ],
 )
-def test_filesystem(version: str, expected_files: List[str]):
-    image = env_util.resolve_image(IMAGE_NAME, version)
+def test_filesystem(image_version: str, expected_files: List[str]):
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -44,7 +44,7 @@ def test_filesystem(version: str, expected_files: List[str]):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_executable(image_version):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stderr_contains=EXPECTED_HELPSTR
     )
@@ -54,7 +54,7 @@ def test_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_pebble_executable(image_version):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -65,7 +65,7 @@ def test_pebble_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_fips(image_version, GOFIPS):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_metallb_controller.py
+++ b/tests/sanity/test_metallb_controller.py
@@ -36,7 +36,9 @@ EXPECTED_HELPSTR = "Usage of /controller:"
     ],
 )
 def test_filesystem(image_version: str, expected_files: List[str]):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -44,7 +46,9 @@ def test_filesystem(image_version: str, expected_files: List[str]):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_executable(image_version):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stderr_contains=EXPECTED_HELPSTR
     )
@@ -54,7 +58,9 @@ def test_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_pebble_executable(image_version):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -65,7 +71,9 @@ def test_pebble_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_fips(image_version, GOFIPS):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_metallb_controller.py
+++ b/tests/sanity/test_metallb_controller.py
@@ -28,7 +28,7 @@ EXPECTED_HELPSTR = "Usage of /controller:"
 
 
 @pytest.mark.parametrize(
-    "version,expected_files",
+    "image_version,expected_files",
     [
         ("v0.14.5", V0_14_5_EXPECTED_FILES),
         ("v0.14.8", V0_14_5_EXPECTED_FILES),

--- a/tests/sanity/test_metallb_controller.py
+++ b/tests/sanity/test_metallb_controller.py
@@ -38,7 +38,7 @@ EXPECTED_HELPSTR = "Usage of /controller:"
 def test_filesystem(image_version: str, expected_files: List[str]):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -48,7 +48,7 @@ def test_filesystem(image_version: str, expected_files: List[str]):
 def test_executable(image_version):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stderr_contains=EXPECTED_HELPSTR
     )
@@ -60,7 +60,7 @@ def test_executable(image_version):
 def test_pebble_executable(image_version):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -73,7 +73,7 @@ def test_pebble_executable(image_version):
 def test_fips(image_version, GOFIPS):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_metallb_controller.py
+++ b/tests/sanity/test_metallb_controller.py
@@ -3,14 +3,20 @@
 # See LICENSE file for licensing details
 #
 
+import shlex
+from pathlib import Path
 from typing import List
 
 import pytest
-from k8s_test_harness.util import docker_util, env_util
+from k8s_test_harness.util import docker_util, env_util, fips_util
 
 # In the future, we may also test ARM
-IMG_PLATFORM = "amd64"
-IMG_NAME = "metallb-controller"
+TEST_PATH = Path(__file__)
+REPO_PATH = TEST_PATH.parent.parent.parent
+IMAGE_NAME = "metallb-controller"
+IMAGE_BASE = f"ghcr.io/canonical/{IMAGE_NAME}"
+IMAGE_ENTRYPOINT = "/controller --help"
+PEBBLE_VERSION = "v1.18.0"
 
 V0_14_5_EXPECTED_FILES = [
     "/controller",
@@ -22,20 +28,63 @@ EXPECTED_HELPSTR = "Usage of /controller:"
 
 
 @pytest.mark.parametrize(
-    "metallb_version,expected_files",
+    "version,expected_files",
     [
         ("v0.14.5", V0_14_5_EXPECTED_FILES),
         ("v0.14.8", V0_14_5_EXPECTED_FILES),
         ("v0.14.9", V0_14_5_EXPECTED_FILES),
     ],
 )
-def test_sanity(metallb_version: str, expected_files: List[str]):
-    rock = env_util.get_build_meta_info_for_rock_version(
-        IMG_NAME, metallb_version, IMG_PLATFORM
+def test_filesystem(version: str, expected_files: List[str]):
+    image = env_util.resolve_image(IMAGE_NAME, version)
+    docker_util.ensure_image_contains_paths_bare(image, expected_files)
+
+
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_executable(image_version):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    docker_util.run_entrypoint_and_assert(
+        image, IMAGE_ENTRYPOINT, expect_stderr_contains=EXPECTED_HELPSTR
     )
 
-    docker_run = docker_util.run_in_docker(rock.image, ["/controller", "--help"])
-    assert EXPECTED_HELPSTR in docker_run.stderr
 
-    # check rock filesystem
-    docker_util.ensure_image_contains_paths_bare(rock.image, expected_files)
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_pebble_executable(image_version):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    docker_util.run_entrypoint_and_assert(
+        image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
+    )
+
+
+@pytest.mark.parametrize("GOFIPS", [0, 1], ids=lambda v: f"GOFIPS={v}")
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_fips(image_version, GOFIPS):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    entrypoint = shlex.split(IMAGE_ENTRYPOINT)
+
+    docker_env = ["-e", f"GOFIPS={GOFIPS}"]
+    process = docker_util.run_in_docker(
+        image, entrypoint, check_exit_code=False, docker_args=docker_env
+    )
+
+    rockcraft_yaml = (
+        (REPO_PATH / "metallb" / image_version / "controller" / "rockcraft.yaml")
+        .read_text()
+        .lower()
+    )
+    expected_returncode, expected_error = fips_util.fips_expectations(
+        rockcraft_yaml, GOFIPS
+    )
+
+    assert (
+        process.returncode == expected_returncode
+    ), f"Return code mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"
+    assert (
+        expected_error in process.stderr
+    ), f"Error message mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"

--- a/tests/sanity/test_metallb_speaker.py
+++ b/tests/sanity/test_metallb_speaker.py
@@ -38,8 +38,8 @@ EXPECTED_HELPSTR = "Usage of /speaker:"
         ("v0.14.9", V0_14_8_EXPECTED_FILES),
     ],
 )
-def test_filesystem(version: str, expected_files: List[str]):
-    image = env_util.resolve_image(IMAGE_NAME, version)
+def test_filesystem(image_version: str, expected_files: List[str]):
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -47,7 +47,7 @@ def test_filesystem(version: str, expected_files: List[str]):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_executable(image_version):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stderr_contains=EXPECTED_HELPSTR
     )
@@ -57,7 +57,7 @@ def test_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_pebble_executable(image_version):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -68,7 +68,7 @@ def test_pebble_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_fips(image_version, GOFIPS):
-    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_metallb_speaker.py
+++ b/tests/sanity/test_metallb_speaker.py
@@ -39,7 +39,9 @@ EXPECTED_HELPSTR = "Usage of /speaker:"
     ],
 )
 def test_filesystem(image_version: str, expected_files: List[str]):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -47,7 +49,9 @@ def test_filesystem(image_version: str, expected_files: List[str]):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_executable(image_version):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stderr_contains=EXPECTED_HELPSTR
     )
@@ -57,7 +61,9 @@ def test_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_pebble_executable(image_version):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -68,7 +74,9 @@ def test_pebble_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
 )
 def test_fips(image_version, GOFIPS):
-    image = env_util.get_build_meta_info_for_rock_version(IMAGE_NAME, image_version, "amd64")
+    image = env_util.get_build_meta_info_for_rock_version(
+        IMAGE_NAME, image_version, "amd64"
+    )
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_metallb_speaker.py
+++ b/tests/sanity/test_metallb_speaker.py
@@ -31,7 +31,7 @@ EXPECTED_HELPSTR = "Usage of /speaker:"
 
 
 @pytest.mark.parametrize(
-    "version,expected_files",
+    "image_version,expected_files",
     [
         ("v0.14.5", V0_14_5_EXPECTED_FILES),
         ("v0.14.8", V0_14_8_EXPECTED_FILES),

--- a/tests/sanity/test_metallb_speaker.py
+++ b/tests/sanity/test_metallb_speaker.py
@@ -41,7 +41,7 @@ EXPECTED_HELPSTR = "Usage of /speaker:"
 def test_filesystem(image_version: str, expected_files: List[str]):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
 
@@ -51,7 +51,7 @@ def test_filesystem(image_version: str, expected_files: List[str]):
 def test_executable(image_version):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.run_entrypoint_and_assert(
         image, IMAGE_ENTRYPOINT, expect_stderr_contains=EXPECTED_HELPSTR
     )
@@ -63,7 +63,7 @@ def test_executable(image_version):
 def test_pebble_executable(image_version):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
     )
@@ -76,7 +76,7 @@ def test_pebble_executable(image_version):
 def test_fips(image_version, GOFIPS):
     image = env_util.get_build_meta_info_for_rock_version(
         IMAGE_NAME, image_version, "amd64"
-    )
+    ).image
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]

--- a/tests/sanity/test_metallb_speaker.py
+++ b/tests/sanity/test_metallb_speaker.py
@@ -3,14 +3,21 @@
 # See LICENSE file for licensing details
 #
 
+import shlex
+from pathlib import Path
 from typing import List
 
 import pytest
-from k8s_test_harness.util import docker_util, env_util
+from k8s_test_harness.util import docker_util, env_util, fips_util
 
 # In the future, we may also test ARM
-IMG_PLATFORM = "amd64"
-IMG_NAME = "metallb-speaker"
+TEST_PATH = Path(__file__)
+REPO_PATH = TEST_PATH.parent.parent.parent
+IMAGE_NAME = "metallb-speaker"
+IMAGE_BASE = f"ghcr.io/canonical/{IMAGE_NAME}"
+IMAGE_ENTRYPOINT = "/speaker --help"
+PEBBLE_VERSION = "v1.18.0"
+
 
 V0_14_5_EXPECTED_FILES = [
     "/speaker",
@@ -24,20 +31,63 @@ EXPECTED_HELPSTR = "Usage of /speaker:"
 
 
 @pytest.mark.parametrize(
-    "metallb_version,expected_files",
+    "version,expected_files",
     [
         ("v0.14.5", V0_14_5_EXPECTED_FILES),
         ("v0.14.8", V0_14_8_EXPECTED_FILES),
         ("v0.14.9", V0_14_8_EXPECTED_FILES),
     ],
 )
-def test_sanity(metallb_version: str, expected_files: List[str]):
-    rock = env_util.get_build_meta_info_for_rock_version(
-        IMG_NAME, metallb_version, IMG_PLATFORM
+def test_filesystem(version: str, expected_files: List[str]):
+    image = env_util.resolve_image(IMAGE_NAME, version)
+    docker_util.ensure_image_contains_paths_bare(image, expected_files)
+
+
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_executable(image_version):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    docker_util.run_entrypoint_and_assert(
+        image, IMAGE_ENTRYPOINT, expect_stderr_contains=EXPECTED_HELPSTR
     )
 
-    docker_run = docker_util.run_in_docker(rock.image, ["/speaker", "--help"])
-    assert EXPECTED_HELPSTR in docker_run.stderr
 
-    # check rock filesystem
-    docker_util.ensure_image_contains_paths_bare(rock.image, expected_files)
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_pebble_executable(image_version):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    docker_util.run_entrypoint_and_assert(
+        image, "/bin/pebble version", expect_stdout_contains=PEBBLE_VERSION
+    )
+
+
+@pytest.mark.parametrize("GOFIPS", [0, 1], ids=lambda v: f"GOFIPS={v}")
+@pytest.mark.parametrize(
+    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, REPO_PATH)
+)
+def test_fips(image_version, GOFIPS):
+    image = env_util.resolve_image(IMAGE_NAME, image_version)
+    entrypoint = shlex.split(IMAGE_ENTRYPOINT)
+
+    docker_env = ["-e", f"GOFIPS={GOFIPS}"]
+    process = docker_util.run_in_docker(
+        image, entrypoint, check_exit_code=False, docker_args=docker_env
+    )
+
+    rockcraft_yaml = (
+        (REPO_PATH / "metallb" / image_version / "speaker" / "rockcraft.yaml")
+        .read_text()
+        .lower()
+    )
+    expected_returncode, expected_error = fips_util.fips_expectations(
+        rockcraft_yaml, GOFIPS
+    )
+
+    assert (
+        process.returncode == expected_returncode
+    ), f"Return code mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"
+    assert (
+        expected_error in process.stderr
+    ), f"Error message mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -47,7 +47,6 @@ allowlist_externals =
     sudo
 commands =
     sudo -E {envpython} -m pytest -v \
-        --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \
         --disable-warnings \
@@ -64,7 +63,6 @@ deps =
     -r {tox_root}/requirements-test.txt
 commands =
     pytest -v \
-        --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \
         --disable-warnings \


### PR DESCRIPTION
# Summary

This PR cleans up and expands the existing test suite to improve maintainability and coverage across FIPS and Pebble-specific functionality.

# Changes

* Consolidated duplicated test logic into the shared k8s-test-harness for easier reuse and consistency.
* Added a dedicated test verifying that FIPS builds are produced and behave as expected.
* Introduced a test to validate the injected Pebble version in the rock image.