### PR TITLE
fix: pin FIPS Go toolchain in override-build step

### DIFF
--- a/frr/9.1.3/rockcraft.yaml
+++ b/frr/9.1.3/rockcraft.yaml
@@ -93,12 +93,6 @@ parts:
       make -j $(nproc)
       make install
 
-  openssl:
-    plugin: nil
-    stage-packages:
-      - openssl-fips-module-3 # a Pro only FIPS package for openssl
-      - openssl # now automatically selected from fips-preview
-
   frr:
     after: [libyang]
     plugin: nil

--- a/metallb/v0.14.5/controller/rockcraft.yaml
+++ b/metallb/v0.14.5/controller/rockcraft.yaml
@@ -36,18 +36,14 @@ parts:
     stage-packages:
       - base-files_tmp
 
-  build-deps:
-    plugin: nil
-    build-snaps:
-      - go/1.22/stable
-
   controller:
-    after: [build-deps]
     plugin: go
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.5
     source-depth: 1
+    build-snaps:
+      - go/1.22/stable
     override-build: |
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.

--- a/metallb/v0.14.5/controller/rockcraft.yaml
+++ b/metallb/v0.14.5/controller/rockcraft.yaml
@@ -37,14 +37,18 @@ parts:
       - base-files_tmp
 
   controller:
-    plugin: go
+    plugin: nil
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.5
     source-depth: 1
-    build-snaps:
-      - go/1.22/stable
     override-build: |
+      # Note(ben): Directly refresh go here to ensure we have
+      # the right version before any go commands are run.
+      # We've seen issues where the go version in build-snaps section
+      # of the part is not used.
+      snap refresh go --channel 1.22/stable
+
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.
       GIT_BRANCH=`git describe --tags --abbrev=0`

--- a/metallb/v0.14.5/speaker/rockcraft.yaml
+++ b/metallb/v0.14.5/speaker/rockcraft.yaml
@@ -42,14 +42,18 @@ parts:
       - base-files_tmp
 
   speaker:
-    plugin: go
+    plugin: nil
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.5
     source-depth: 1
-    build-snaps:
-      - go/1.22/stable
     override-build: |
+      # Note(ben): Directly refresh go here to ensure we have
+      # the right version before any go commands are run.
+      # We've seen issues where the go version in build-snaps section
+      # of the part is not used.
+      snap refresh go --channel 1.22/stable
+
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.
       GIT_BRANCH=`git describe --tags --abbrev=0`

--- a/metallb/v0.14.5/speaker/rockcraft.yaml
+++ b/metallb/v0.14.5/speaker/rockcraft.yaml
@@ -41,18 +41,14 @@ parts:
     stage-packages:
       - base-files_tmp
 
-  build-deps:
-    plugin: nil
-    build-snaps:
-      - go/1.22/stable
-
   speaker:
-    after: [build-deps]
     plugin: go
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.5
     source-depth: 1
+    build-snaps:
+      - go/1.22/stable
     override-build: |
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.

--- a/metallb/v0.14.8/controller/rockcraft.yaml
+++ b/metallb/v0.14.8/controller/rockcraft.yaml
@@ -42,9 +42,13 @@ parts:
     source: https://github.com/metallb/metallb
     source-tag: v0.14.8
     source-depth: 1
-    build-snaps:
-      - go/1.22/stable
     override-build: |
+      # Note(ben): Directly refresh go here to ensure we have
+      # the right version before any go commands are run.
+      # We've seen issues where the go version in build-snaps section
+      # of the part is not used.
+      snap refresh go --channel 1.22/stable
+
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.
       GIT_BRANCH=`git describe --tags --abbrev=0`

--- a/metallb/v0.14.8/controller/rockcraft.yaml
+++ b/metallb/v0.14.8/controller/rockcraft.yaml
@@ -36,18 +36,14 @@ parts:
     stage-packages:
       - base-files_tmp
 
-  build-deps:
-    plugin: nil
-    build-snaps:
-      - go/1.22/stable
-
   controller:
-    after: [build-deps]
     plugin: go
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.8
     source-depth: 1
+    build-snaps:
+      - go/1.22/stable
     override-build: |
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.

--- a/metallb/v0.14.8/speaker/rockcraft.yaml
+++ b/metallb/v0.14.8/speaker/rockcraft.yaml
@@ -41,18 +41,14 @@ parts:
     stage-packages:
       - base-files_tmp
 
-  build-deps:
-    plugin: nil
-    build-snaps:
-      - go/1.22/stable
-
   speaker:
-    after: [build-deps]
     plugin: go
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.8
     source-depth: 1
+    build-snaps:
+      - go/1.22/stable
     override-build: |
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.

--- a/metallb/v0.14.8/speaker/rockcraft.yaml
+++ b/metallb/v0.14.8/speaker/rockcraft.yaml
@@ -42,14 +42,18 @@ parts:
       - base-files_tmp
 
   speaker:
-    plugin: go
+    plugin: nil
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.8
     source-depth: 1
-    build-snaps:
-      - go/1.22/stable
     override-build: |
+      # Note(ben): Directly refresh go here to ensure we have
+      # the right version before any go commands are run.
+      # We've seen issues where the go version in build-snaps section
+      # of the part is not used.
+      snap refresh go --channel 1.22/stable
+
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.
       GIT_BRANCH=`git describe --tags --abbrev=0`

--- a/metallb/v0.14.9/controller/rockcraft.yaml
+++ b/metallb/v0.14.9/controller/rockcraft.yaml
@@ -20,20 +20,14 @@ services:
     startup: enabled
 
 parts:
-  build-deps:
-    plugin: nil
-    build-snaps:
-      - go/1.22-fips/stable
-
   openssl:
     plugin: nil
     stage-packages:
-      - openssl-fips-module-3 # a Pro only FIPS package for openssl
-      - openssl # now automatically selected from fips-preview
+      - openssl-fips-module-3
+      - openssl
 
   controller:
-    after: [build-deps]
-    plugin: go
+    plugin: nil
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.9
@@ -43,10 +37,14 @@ parts:
       # We'll use the tag name.
       GIT_BRANCH=`git describe --tags --abbrev=0`
 
+      # Note(ben): Override go.mod required Go version to 1.24
+      # since there is a bug in go-snap 1.22 and 1.23 FIPS that
+      # causes the build to not be fips compliant.
+      snap refresh go --channel 1.24-fips/stable
+
       export CGO_ENABLED=1
       export GOTOOLCHAIN=local
       export GOEXPERIMENT="opensslcrypto"
-
       go build -v -o $CRAFT_PART_INSTALL/controller \
         -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
         ./controller

--- a/metallb/v0.14.9/controller/rockcraft.yaml
+++ b/metallb/v0.14.9/controller/rockcraft.yaml
@@ -33,14 +33,14 @@ parts:
     source-tag: v0.14.9
     source-depth: 1
     override-build: |
-      GIT_COMMIT=`git rev-parse HEAD`
-      # We'll use the tag name.
-      GIT_BRANCH=`git describe --tags --abbrev=0`
-
       # Note(ben): Override go.mod required Go version to 1.24
       # since there is a bug in go-snap 1.22 and 1.23 FIPS that
       # causes the build to not be fips compliant.
       snap refresh go --channel 1.24-fips/stable
+
+      GIT_COMMIT=`git rev-parse HEAD`
+      # We'll use the tag name.
+      GIT_BRANCH=`git describe --tags --abbrev=0`
 
       export CGO_ENABLED=1
       export GOTOOLCHAIN=local

--- a/metallb/v0.14.9/speaker/rockcraft.yaml
+++ b/metallb/v0.14.9/speaker/rockcraft.yaml
@@ -33,14 +33,14 @@ parts:
     source-tag: v0.14.9
     source-depth: 1
     override-build: |
-      GIT_COMMIT=`git rev-parse HEAD`
-      # We'll use the tag name.
-      GIT_BRANCH=`git describe --tags --abbrev=0`
-
       # Note(ben): Override go.mod required Go version to 1.24
       # since there is a bug in go-snap 1.22 and 1.23 FIPS that
       # causes the build to not be fips compliant.
       snap refresh go --channel 1.24-fips/stable
+
+      GIT_COMMIT=`git rev-parse HEAD`
+      # We'll use the tag name.
+      GIT_BRANCH=`git describe --tags --abbrev=0`
 
       export CGO_ENABLED=1
       export GOTOOLCHAIN=local

--- a/metallb/v0.14.9/speaker/rockcraft.yaml
+++ b/metallb/v0.14.9/speaker/rockcraft.yaml
@@ -20,11 +20,6 @@ services:
     startup: enabled
 
 parts:
-  build-deps:
-    plugin: nil
-    build-snaps:
-      - go/1.23-fips/stable
-
   openssl:
     plugin: nil
     stage-packages:
@@ -32,7 +27,6 @@ parts:
       - openssl # now automatically selected from fips-preview
 
   speaker:
-    after: [build-deps]
     plugin: go
     source-type: git
     source: https://github.com/metallb/metallb
@@ -42,6 +36,11 @@ parts:
       GIT_COMMIT=`git rev-parse HEAD`
       # We'll use the tag name.
       GIT_BRANCH=`git describe --tags --abbrev=0`
+
+      # Note(ben): Override go.mod required Go version to 1.24
+      # since there is a bug in go-snap 1.22 and 1.23 FIPS that
+      # causes the build to not be fips compliant.
+      snap refresh go --channel 1.24-fips/stable
 
       export CGO_ENABLED=1
       export GOTOOLCHAIN=local


### PR DESCRIPTION
Rockcraft overrides the Go version during the Pebble build when `GOTOOLCHAIN` is set to `local`,
which causes the binaries to be built with a non-FIPS toolchain and breaks compliance.

In addition, the Go FIPS tracks `1.22` and `1.23` appear to contain a bug that prevents proper FIPS enforcement. To ensure compliance, the build now explicitly uses the `1.24` FIPS Go version.