### PR TITLE
feat: add MetalLB v0.15.3 and FRR 10.4.1 support

### DIFF
--- a/frr/10.4.1/rockcraft.yaml
+++ b/frr/10.4.1/rockcraft.yaml
@@ -1,0 +1,143 @@
+name: frr
+summary: Rock for FRRouting.
+description: >
+  This rock is a drop in replacement for the
+  quay.io/frrouting/frr image.
+version: 10.4.1
+license: Apache-2.0
+
+base: ubuntu@22.04
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+entrypoint-service: frr
+services:
+  frr:
+    command: /usr/sbin/docker-start [ -h ]
+    override: replace
+    startup: enabled
+
+parts:
+  build-deps:
+    plugin: nil
+    build-packages:
+      # Basic build requirements from documentation
+      - autoconf
+      - automake
+      - bison
+      - build-essential
+      - flex
+      - git
+      - install-info
+      - libc-ares-dev
+      - libcap-dev
+      - libelf-dev
+      - libjson-c-dev
+      - libpam0g-dev
+      - libreadline-dev
+      - libsnmp-dev
+      - libsqlite3-dev
+      - libtool
+      - make
+      - perl
+      - pkg-config
+      - python3-dev
+      - python3-sphinx
+      - texinfo
+      #  Protobuf build requirements
+      - libprotobuf-c-dev
+      - protobuf-c-compiler
+      #  Libyang2 extra build requirements
+      - cmake
+      - libpcre2-dev
+      #  GRPC extra build requirements
+      - libgrpc-dev
+      - libgrpc++-dev
+      - protobuf-compiler-grpc
+      # additional requirements
+      - liblua5.3-dev
+      - libssl-dev
+      - lua5.3
+      - librtr-dev
+
+  users:
+    after: [build-deps]
+    plugin: nil
+    overlay-script: |
+      groupadd -R $CRAFT_OVERLAY -r -g 92 frr
+      groupadd -R $CRAFT_OVERLAY -r -g 85 frrvty
+
+      useradd -R $CRAFT_OVERLAY -r -u 92 -g 85 \
+        -d /home/frr -s /bin/bash -m frr
+      usermod -R $CRAFT_OVERLAY -a -G frrvty frr
+
+      mkdir -p $CRAFT_OVERLAY/etc/sudoers.d
+      echo 'frr ALL = NOPASSWD: ALL' | tee $CRAFT_OVERLAY/etc/sudoers.d/frr
+
+  libyang:
+    after: [users]
+    plugin: nil
+    source-type: git
+    source: https://github.com/CESNET/libyang.git
+    source-tag: v2.1.128
+    source-depth: 1
+    override-build: |
+      mkdir -p build
+      cd build
+      mkdir -p $CRAFT_PART_INSTALL/usr
+
+      cmake -DCMAKE_INSTALL_PREFIX:PATH=$CRAFT_PART_INSTALL/usr \
+          -DCMAKE_BUILD_TYPE:String="Release" ..
+      make -j $(nproc)
+      make install
+
+  frr:
+    after: [libyang]
+    plugin: nil
+    source-type: git
+    source: https://github.com/FRRouting/frr
+    source-tag: docker/10.4.1
+    source-depth: 1
+    override-build: |
+      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CRAFT_STAGE/usr/lib
+
+      ./bootstrap.sh
+      ./configure \
+         --prefix=$CRAFT_PART_INSTALL/usr \
+         --sysconfdir=/etc \
+         --localstatedir=/var \
+         --sbindir=$CRAFT_PART_INSTALL/usr/lib/frr \
+         --enable-rpki \
+         --enable-vtysh \
+         --enable-multipath=64 \
+         --enable-vty-group=frrvty \
+         --enable-user=frr \
+         --enable-group=frr \
+         --enable-scripting
+      make -j $(nproc)
+      make install
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/sbin
+      cp $CRAFT_PART_SRC/docker/debian/docker-start \
+        $CRAFT_PART_INSTALL/usr/sbin/docker-start
+
+  runtime-deps:
+    plugin: nil
+    stage-packages:
+      - libc-ares2
+      - libcap2
+      - libjson-c5
+      - libpam0g
+      - libreadline8
+      - libsnmp40
+      - libsqlite3-0
+      - libprotobuf-c1
+      - libpcre2-posix3
+      - libgrpc++1
+      - libgrpc10
+      - liblua5.3-0
+      - lua5.3
+      - libssl3
+      - librtr0

--- a/metallb/v0.15.3/controller/rockcraft.yaml
+++ b/metallb/v0.15.3/controller/rockcraft.yaml
@@ -1,0 +1,50 @@
+name: metallb-controller
+summary: Rock for the Metallb controller.
+description: >
+  This rock is a drop in replacement for the
+  quay.io/metallb/controller image.
+version: v0.15.3
+license: Apache-2.0
+
+base: bare
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
+
+entrypoint-service: controller
+services:
+  controller:
+    command: /controller [ -h ]
+    override: replace
+    startup: enabled
+
+parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3
+      - openssl
+
+  controller:
+    plugin: nil
+    source-type: git
+    source: https://github.com/metallb/metallb
+    source-tag: v0.15.3
+    source-depth: 1
+    override-build: |
+      snap refresh go --channel 1.25-fips/stable
+
+      GIT_COMMIT=`git rev-parse HEAD`
+      # We'll use the tag name.
+      GIT_BRANCH=`git describe --tags --abbrev=0`
+
+      export CGO_ENABLED=1
+      export GOTOOLCHAIN=local
+      export GOEXPERIMENT="opensslcrypto"
+      go build -v -o $CRAFT_PART_INSTALL/controller \
+        -tags "linux,cgo,ms_tls13kdf" \
+        -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+        ./controller
+
+      cp $CRAFT_PART_BUILD/LICENSE $CRAFT_PART_INSTALL/

--- a/metallb/v0.15.3/controller/rockcraft.yaml
+++ b/metallb/v0.15.3/controller/rockcraft.yaml
@@ -7,7 +7,7 @@ version: v0.15.3
 license: Apache-2.0
 
 base: bare
-build-base: ubuntu@24.04
+build-base: ubuntu@22.04
 platforms:
   amd64:
   arm64:

--- a/metallb/v0.15.3/speaker/rockcraft.yaml
+++ b/metallb/v0.15.3/speaker/rockcraft.yaml
@@ -1,0 +1,65 @@
+name: metallb-speaker
+summary: Rock for the Metallb speaker.
+description: >
+  This rock is a drop in replacement for the
+  quay.io/metallb/speaker image.
+version: v0.15.3
+license: Apache-2.0
+
+base: bare
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
+
+entrypoint-service: speaker
+services:
+  speaker:
+    command: /speaker [ -h ]
+    override: replace
+    startup: enabled
+
+parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
+  speaker:
+    plugin: go
+    source-type: git
+    source: https://github.com/metallb/metallb
+    source-tag: v0.15.3
+    source-depth: 1
+    override-build: |
+      snap refresh go --channel 1.25-fips/stable
+
+      GIT_COMMIT=`git rev-parse HEAD`
+      # We'll use the tag name.
+      GIT_BRANCH=`git describe --tags --abbrev=0`
+
+      export CGO_ENABLED=1
+      export GOTOOLCHAIN=local
+      export GOEXPERIMENT="opensslcrypto"
+
+      # build frr metrics
+      go build -v -o $CRAFT_PART_INSTALL/frr-metrics \
+        -tags "linux,cgo,ms_tls13kdf" \
+        -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+        ./frr-tools/metrics/exporter.go
+
+      # build cp-tool
+      go build -v -o $CRAFT_PART_INSTALL/cp-tool \
+        -tags "linux,cgo,ms_tls13kdf" \
+        -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+        ./frr-tools/cp-tool/cp-tool.go
+
+      # build speaker
+      go build -v -o $CRAFT_PART_INSTALL/speaker \
+        -tags "linux,cgo,ms_tls13kdf" \
+        -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+        ./speaker
+
+      cp $CRAFT_PART_BUILD/LICENSE $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/frr-tools/reloader/frr-reloader.sh $CRAFT_PART_INSTALL/

--- a/metallb/v0.15.3/speaker/rockcraft.yaml
+++ b/metallb/v0.15.3/speaker/rockcraft.yaml
@@ -7,7 +7,7 @@ version: v0.15.3
 license: Apache-2.0
 
 base: bare
-build-base: ubuntu@24.04
+build-base: ubuntu@22.04
 platforms:
   amd64:
   arm64:

--- a/tests/integration/test_metallb.py
+++ b/tests/integration/test_metallb.py
@@ -19,7 +19,12 @@ def _get_rock_image(name: str, version: str):
 
 @pytest.mark.parametrize(
     "metallb_version,frr_version",
-    [("v0.14.5", "9.0.2"), ("v0.14.8", "9.1.0"), ("v0.14.9", "9.1.3"), ("v0.15.3", "10.4.1")],
+    [
+        ("v0.14.5", "9.0.2"),
+        ("v0.14.8", "9.1.0"),
+        ("v0.14.9", "9.1.3"),
+        ("v0.15.3", "10.4.1"),
+    ],
 )
 def test_metallb(
     function_instance: harness.Instance, metallb_version: str, frr_version: str

--- a/tests/integration/test_metallb.py
+++ b/tests/integration/test_metallb.py
@@ -19,7 +19,7 @@ def _get_rock_image(name: str, version: str):
 
 @pytest.mark.parametrize(
     "metallb_version,frr_version",
-    [("v0.14.5", "9.0.2"), ("v0.14.8", "9.1.0"), ("v0.14.9", "9.1.3")],
+    [("v0.14.5", "9.0.2"), ("v0.14.8", "9.1.0"), ("v0.14.9", "9.1.3"), ("v0.15.3", "10.4.1")],
 )
 def test_metallb(
     function_instance: harness.Instance, metallb_version: str, frr_version: str

--- a/tests/sanity/test_frr.py
+++ b/tests/sanity/test_frr.py
@@ -19,7 +19,7 @@ EXPECTED_FILES = [
 EXPECTED_HELPSTR = "Watchdog program to monitor status of frr daemons"
 
 
-@pytest.mark.parametrize("frr_version", ["9.0.2", "9.1.0", "9.1.3"])
+@pytest.mark.parametrize("frr_version", ["9.0.2", "9.1.0", "9.1.3", "10.4.1"])
 def test_sanity(frr_version: str):
     rock = env_util.get_build_meta_info_for_rock_version(
         IMG_NAME, frr_version, IMG_PLATFORM

--- a/tests/sanity/test_metallb_controller.py
+++ b/tests/sanity/test_metallb_controller.py
@@ -27,6 +27,7 @@ EXPECTED_HELPSTR = "Usage of /controller:"
         ("v0.14.5", V0_14_5_EXPECTED_FILES),
         ("v0.14.8", V0_14_5_EXPECTED_FILES),
         ("v0.14.9", V0_14_5_EXPECTED_FILES),
+        ("v0.15.3", V0_14_5_EXPECTED_FILES),
     ],
 )
 def test_sanity(metallb_version: str, expected_files: List[str]):

--- a/tests/sanity/test_metallb_speaker.py
+++ b/tests/sanity/test_metallb_speaker.py
@@ -29,6 +29,7 @@ EXPECTED_HELPSTR = "Usage of /speaker:"
         ("v0.14.5", V0_14_5_EXPECTED_FILES),
         ("v0.14.8", V0_14_8_EXPECTED_FILES),
         ("v0.14.9", V0_14_8_EXPECTED_FILES),
+        ("v0.15.3", V0_14_8_EXPECTED_FILES),
     ],
 )
 def test_sanity(metallb_version: str, expected_files: List[str]):


### PR DESCRIPTION
Metallb v0.15.3 uses FRR 10.4.1, see [here](https://github.com/metallb/metallb/blob/v0.15.3/config/frr/speaker-patch.yaml#L66).
