### PR TITLE
docs: Update FIPS documentation to reference k8s-snap docs

### DIFF
--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,83 +1,35 @@
-# MetalLB FIPS compliance analysis
+# MetalLB FIPS Compliance
 
-The following document summarizes the current state of [FIPS 140-3] compliance for MetalLB, focusing on its cryptographic components and build requirements. This overview is intended to guide users and developers in understanding the compliance status and necessary steps for achieving FIPS mode operation.
+For comprehensive information about FIPS 140-3 compliance in Canonical Kubernetes, including how ROCKs are built with FIPS support, please refer to the [k8s-snap FIPS documentation](https://github.com/canonical/k8s-snap/blob/main/docs/dev/fips.md).
 
 > **Note:** As of now, FRR and pebble are not built in a FIPS-compliant way. This document will be updated once they are.
 
-## Abbreviations
+## MetalLB-Specific Information
 
-This document uses a set of abbreviations which are explained below:
+### BGP Authentication and FIPS
 
-- **Federal Information Processing Standards (FIPS)**: A set of standards for cryptographic modules published by the U.S. government.
-- **Border Gateway Protocol (BGP)**: A standardized exterior gateway protocol for exchanging routing information between autonomous systems on the internet.
-- **Transport Layer Security (TLS)**: A cryptographic protocol designed to provide secure communication over a computer network.
-- **Open Source Routing Software (FRR)**: A routing software suite used for network routing protocols.
-- **Network Discovery Protocol (NDP)**: A protocol in the IPv6 suite for neighbor discovery.
-- **Advanced Package Tool (APT)**: A package management system used by Debian-based Linux distributions.
+While MetalLB allows MD5 authentication for BGP sessions, **MD5 is not FIPS-compliant** and should be avoided in FIPS mode. MD5 authentication calls will fail on a FIPS-enabled system.
 
-## Cryptographic implementation analysis
+### FRR Mode
 
-MetalLB's cryptographic footprint is limited and primarily involves secure communication between components and with the Kubernetes API. The speaker uses minimal cryptography, mainly for BGP authentication and communication with the controller, while the controller relies on TLS for Kubernetes API interactions. FIPS compliance depends on the cryptographic libraries and build environment used for these components.
+FRR mode is not FIPS-compliant. However, enabling FRR mode is not supported in Canonical Kubernetes, so this does not impact FIPS compliance for users of that Kubernetes distribution.
 
-### Speaker Component
+### Component Details
+
+#### Speaker Component
 
 MetalLB's speaker component primarily handles BGP/NDP protocols and service advertisement. The speaker's cryptographic usage is minimal and focused on:
 
-- Secure communication with the controller (if using the layer 2 mode), see [speaker source]
-- BGP session security when configured with authentication (Note: While Metallb allows MD5 it is not FIPS compliant and should be avoided in FIPS mode. MD5 calls will fail on a FIPS-enabled system.)
+- Secure communication with the controller (if using the layer 2 mode)
+- BGP session security when configured with authentication (Note: MD5 authentication is not FIPS-compliant)
 
-### Controller Component
+See [speaker source](https://github.com/metallb/metallb/blob/main/internal/speakerlist/speakerlist.go#L16).
+
+#### Controller Component
 
 The controller handles the Kubernetes API communication and IP address management. Its cryptographic usage includes:
 
 - TLS for secure communication with the Kubernetes API server
 - Certificate validation for webhook servers
 
-See [controller source]
-
-## FIPS Compliance Status
-
-### Implementation
-
-MetalLB's current implementation uses Go's standard `crypto` packages, which are FIPS-compliant when built with the appropriate toolchain.
-If turned on, FRR mode is not FIPS-compliant. However, enabling FRR mode is not supported in Canonical Kubernetes, so this does not impact 
-FIPS compliance for the users of that Kubernetes distribution.
-
-The following requirements must be met:
-
-1. **Go Toolchain**: Must use the modified [Go toolchain from Microsoft]
-2. **OpenSSL**: Must link against a FIPS-validated OpenSSL implementation.
-
-**NOTE**: This ROCK is bundled with a FIPS-validated OpenSSL library which is described in the ROCK manifest (see [this discourse post]).
-```yaml
-...
-parts:
-  openssl:
-    plugin: nil
-    stage-packages:
-      - openssl-fips-module-3
-      - openssl
-...
-```
-
-### Required Build Modifications
-
-**Prerequisites**:
-
-- a `rockcraft` version that allows building with Ubuntu Pro services (refer to [this discourse post]).
-
-**Building the Image**:
-
-Use the following command to build the image:
-
-```bash
-sudo rockcraft pack --pro=fips-updates
-```
-
-<!-- LINKS -->
-
-[FIPS 140-3]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-3.pdf
-[speaker source]: https://github.com/metallb/metallb/blob/main/internal/speakerlist/speakerlist.go#L16
-[controller source]: https://github.com/metallb/metallb/blob/659944f6cfbad3c7ef84fe975aa9811b9821aa57/internal/k8s/k8s.go#L7-L8
-[Go toolchain from Microsoft]: https://github.com/microsoft/go/blob/microsoft/release-branch.go1.23/eng/doc/fips/README.md
-[this discourse post]: https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+See [controller source](https://github.com/metallb/metallb/blob/659944f6cfbad3c7ef84fe975aa9811b9821aa57/internal/k8s/k8s.go#L7-L8).

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -4,19 +4,15 @@ For comprehensive information about FIPS 140-3 compliance in Canonical Kubernete
 
 > **Note:** As of now, FRR and pebble are not built in a FIPS-compliant way. This document will be updated once they are.
 
-## MetalLB-Specific Information
-
-### BGP Authentication and FIPS
+## BGP Authentication and FIPS
 
 While MetalLB allows MD5 authentication for BGP sessions, **MD5 is not FIPS-compliant** and should be avoided in FIPS mode. MD5 authentication calls will fail on a FIPS-enabled system.
 
-### FRR Mode
+## FRR Mode
 
 FRR mode is not FIPS-compliant. However, enabling FRR mode is not supported in Canonical Kubernetes, so this does not impact FIPS compliance for users of that Kubernetes distribution.
 
-### Component Details
-
-#### Speaker Component
+## Speaker
 
 MetalLB's speaker component primarily handles BGP/NDP protocols and service advertisement. The speaker's cryptographic usage is minimal and focused on:
 
@@ -25,7 +21,7 @@ MetalLB's speaker component primarily handles BGP/NDP protocols and service adve
 
 See [speaker source](https://github.com/metallb/metallb/blob/main/internal/speakerlist/speakerlist.go#L16).
 
-#### Controller Component
+## Controller
 
 The controller handles the Kubernetes API communication and IP address management. Its cryptographic usage includes:
 

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -10,7 +10,7 @@ While MetalLB allows MD5 authentication for BGP sessions, **MD5 is not FIPS-comp
 
 ## FRR Mode
 
-FRR mode is not FIPS-compliant. However, enabling FRR mode is not supported in Canonical Kubernetes, so this does not impact FIPS compliance for users of that Kubernetes distribution.
+FRR mode is not FIPS-compliant. However, enabling FRR mode is not supported in Canonical Kubernetes, so this does not impact FIPS compliance for our users.
 
 ## Speaker
 


### PR DESCRIPTION
- Remove duplicate general FIPS information
- Keep MetalLB-specific details (MD5, FRR, component crypto usage)
- Reference comprehensive k8s-snap FIPS documentation