### PR TITLE
ci: use latest/edge rockcraft channel

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -17,7 +17,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "linux", "arm64", "jammy", "xlarge"], "amd64": ["self-hosted", "linux", "amd64", "jammy", "xlarge"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
+      force-build: true
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
+    permissions:
+      contents: read
+      packages: write
     uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
     with:
       owner: ${{ github.repository_owner }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,6 +30,9 @@ jobs:
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
+    permissions:
+      security-events: write
+      packages: read
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab
     needs: [build-and-push-arch-specifics]
     secrets: inherit

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@1f72669125e711d252c472f45ad98f22ff592d28
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -20,7 +20,6 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "linux", "arm64", "jammy", "xlarge"], "amd64": ["self-hosted", "linux", "amd64", "jammy", "xlarge"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      force-build: true
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/frr/10.4.1/.rockcraft-version.yaml
+++ b/frr/10.4.1/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/frr/9.0.2/.rockcraft-version.yaml
+++ b/frr/9.0.2/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/frr/9.1.0/.rockcraft-version.yaml
+++ b/frr/9.1.0/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/frr/9.1.3/.rockcraft-version.yaml
+++ b/frr/9.1.3/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/metallb/v0.14.5/.rockcraft-version.yaml
+++ b/metallb/v0.14.5/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/metallb/v0.14.5/controller/rockcraft.yaml
+++ b/metallb/v0.14.5/controller/rockcraft.yaml
@@ -38,6 +38,8 @@ parts:
 
   controller:
     plugin: nil
+    build-snaps:
+      - go
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.5

--- a/metallb/v0.14.5/speaker/rockcraft.yaml
+++ b/metallb/v0.14.5/speaker/rockcraft.yaml
@@ -43,6 +43,8 @@ parts:
 
   speaker:
     plugin: nil
+    build-snaps:
+      - go
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.5

--- a/metallb/v0.14.8/.rockcraft-version.yaml
+++ b/metallb/v0.14.8/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/metallb/v0.14.8/controller/rockcraft.yaml
+++ b/metallb/v0.14.8/controller/rockcraft.yaml
@@ -38,6 +38,8 @@ parts:
 
   controller:
     plugin: go
+    build-snaps:
+      - go
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.8

--- a/metallb/v0.14.8/speaker/rockcraft.yaml
+++ b/metallb/v0.14.8/speaker/rockcraft.yaml
@@ -43,6 +43,8 @@ parts:
 
   speaker:
     plugin: nil
+    build-snaps:
+      - go
     source-type: git
     source: https://github.com/metallb/metallb
     source-tag: v0.14.8

--- a/metallb/v0.14.9/.rockcraft-version.yaml
+++ b/metallb/v0.14.9/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/metallb/v0.15.3/.rockcraft-version.yaml
+++ b/metallb/v0.15.3/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge


### PR DESCRIPTION
## Summary

Mirrors the changes from [cilium-rocks#59](https://github.com/canonical/cilium-rocks/pull/59) onto metallb-rocks:

- Switch the `build_rocks` shared workflow to `canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach`.
- Remove the repo-wide `rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'` pin and enable `force-build: true`.
- Add a per-version `.rockcraft-version.yaml` selecting the `latest/edge` channel for every rock we build (4 `frr` + 4 `metallb` versions).

## Why

The shared build workflow's rockcraft resolver walks from each rock directory upward but never the repo root, so a root-level `.rockcraft-version.yaml` would never be consulted for nested rocks. Placing the file in each version directory makes the channel selection effective. Moving from a pinned revision to `latest/edge` picks up newer rockcraft handling of the FIPS apt-overlay (the same deterministic FIPS build failure motivated the cilium change).

Placement (matches the resolver, which reads the rock dir and its parents):
- `frr/X.Y.Z/.rockcraft-version.yaml` — `rockcraft.yaml` lives directly in the version dir.
- `metallb/vX.Y.Z/.rockcraft-version.yaml` — covers both the `controller` and `speaker` rocks.

Each file:

```yaml
versions:
  - architecture: amd64
    channel: latest/edge
  - architecture: arm64
    channel: latest/edge
```

## Notes / differences from the cilium PR

- **PEBBLE_VERSION** — the cilium PR set `PEBBLE_VERSION = os.getenv(...) or "fips"` in `tests/sanity/test_util/config.py`. metallb-rocks has no such sanity config and no pebble version reference, so there is no equivalent target and nothing was changed.
- **delve `@v1.26.3` pin** — cilium-specific (`debug-wrapper` part). metallb rocks have no delve usage, so N/A.
- Only the `build_rocks` job reference was changed; `run_tests`, `scan_images`, and `assemble_multiarch_image` remain pinned to `6b24c265…`.
